### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 FireTitle
 =========
 
-An extension for **enhanced presentation of titles** in tabs and title bars of Firefox. 
+An extension for **enhanced presentation of titles** in tabs and title bars of Firefox and Firefox-based browsers. 
 
 The original _FireTitle_:
 
-- uses a legacy technology (XUL)
+- uses a technology – [XUL](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL) – that is legacy for add-on purposes
 - is stable, but no longer developed
 - may be effectively passed through the [Extension Converter for SeaMonkey](http://addonconverter.fotokraina.com/)
-- will not work with Firefox 57.
+- does not work with Firefox Quantum.
 
 The new _Crappy Firetitle_: 
 
-- is for Firefox 56 and later
-- is constrained by [WebExtensions APIs](https://wiki.mozilla.org/WebExtensions).
+- is for Firefox for Android 57.0 and later, Firefox 57.0 and later 
+- [is constrained](https://bugzilla.mozilla.org/show_bug.cgi?id=1396010#a13659144_582971) by [WebExtensions APIs](https://wiki.mozilla.org/WebExtensions).
 
 ## Links
 


### PR DESCRIPTION
A mention of 'Firefox-based' browsers (without naming any one fork). 

Reference to the 'design-decision-denied' part of Mozilla bug 1396010.